### PR TITLE
ci: adiciona workflow para executar testes E2E

### DIFF
--- a/.github/workflows/run-e2e-tests.yml
+++ b/.github/workflows/run-e2e-tests.yml
@@ -1,0 +1,32 @@
+name: Run E2E Tests
+
+on: ["pull_request"]
+
+jobs:
+  run-unit-tests:
+    name: Run E2E Tests
+    runs-on: ubuntu-latest
+
+    services: 
+      postgres:
+        image: bitnami/postgresql
+        ports:
+          - 5432:5432
+        env:
+          POSTGRESQL_USERNAME: docker
+          POSTGRESQL_PASSWORD: docker
+          POSTGRESQL_DATABASE: apisolid
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 20
+          cache: 'npm'
+
+      - run: npm ci
+      
+      - run: npm run test:e2e
+        env:
+          JWT_SECRET: testing
+          DATABASE_URL: "postgres://docker:docker@localhost:5432/apisolid"

--- a/src/utils/test/create-and-authenticate-user.ts
+++ b/src/utils/test/create-and-authenticate-user.ts
@@ -41,7 +41,6 @@ export async function createAndAuthenticateUser(
       role: data.isAdmin ? 'ADMIN' : 'MEMBER',
     },
   })
-  console.log(user)
   const authResponse = await request(app.server).post('/sessions').send({
     email: user.email,
     password: data.password,


### PR DESCRIPTION
- Cria novo arquivo .github/workflows/run-e2e-tests.yml
- Configura job para rodar testes E2E em pull requests
- Utiliza serviço PostgreSQL para testes
- Define variáveis de ambiente necessárias